### PR TITLE
OM-1340 - don't animate layout when using `display()`

### DIFF
--- a/Symphony/ParentViewController.swift
+++ b/Symphony/ParentViewController.swift
@@ -38,6 +38,8 @@ public final class ParentViewController: UIViewController {
         displayedViewController = viewController
         addChildViewController(viewController)
         viewController.view.frame = view.bounds
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
         view.addSubview(viewController.view)
         viewController.didMove(toParentViewController: self)
         setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
This method sets the new view controller's view's frame. The system was then animating the view's subviews from the view's old bounds of (0,0) to its new bounds. I told the view to lay itself out immediately instead.